### PR TITLE
Added support writing CR and LF to LCD

### DIFF
--- a/src/UC1701.cpp
+++ b/src/UC1701.cpp
@@ -140,6 +140,22 @@ size_t UC1701::write(uint8_t chr)
 #endif
     }
 
+    if (chr == '\r') {
+        this->setCursor(0, this->line);
+#if ARDUINO < 100
+        return;
+#else
+        return 1;
+#endif
+    } else if (chr == '\n') {
+        this->setCursor(this->column, this->line + 1);
+#if ARDUINO < 100
+        return;
+#else
+        return 1;
+#endif
+    }
+
     const unsigned char *glyph;
     unsigned char pgm_buffer[5];
 


### PR DESCRIPTION
This Pull Request add support for CR and LF characters being written to the LCD.

This means that lcd.println() works correctly, making it easier to write multiple lines of text with using lcd.setCursor() between each lcd.print().

The disadvantage is that you can no-longer use characters 10 and 13 for user-defined glyphs.

So far I am only using 2 custom glyphs in my project anyway.


I submitted this once already:
https://github.com/Industruino/UC1701-OLD/pull/3

I am not sure why this new repository was created?
