### PR TITLE
Clear "redefinition of class UC1701" error

### DIFF
--- a/src/UC1701.h
+++ b/src/UC1701.h
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  */
 
+#ifndef UC1701_H_
+#define UC1701_H_
 
 #if ARDUINO < 100
 #include <WProgram.h>
@@ -93,4 +95,4 @@ class UC1701: public Print {
 
 };
 
-
+#endif // UC1701_H_


### PR DESCRIPTION
Depending on the program structure, header files can be included more than once in the program code. This means that the class would be redefined, which results in a compiler error. To avoid this, I added this standard macro to make the preprocessor add the code only once and therefore avoid the said compiler error.

Compiler error:
"error: redefinition of 'class UC1701'
 class UC1701: public Print {"